### PR TITLE
Cleaning prisma query engine after tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+/*  eslint-disable max-len  */
+
 /*
  * For a detailed explanation regarding each configuration property and type check, visit:
  * https://jestjs.io/docs/en/configuration.html
@@ -23,7 +25,7 @@ module.exports = {
   // collectCoverageFrom: undefined,
 
   // The directory where Jest should output its coverage files
-  coverageDirectory: "../coverage",
+  coverageDirectory: '../coverage',
 
   // An array of regexp pattern strings used to skip coverage collection
   // coveragePathIgnorePatterns: [
@@ -31,7 +33,7 @@ module.exports = {
   // ],
 
   // Indicates which provider should be used to instrument code for coverage
-  coverageProvider: "v8",
+  coverageProvider: 'v8',
 
   // A list of reporter names that Jest uses when writing coverage reports
   // coverageReporters: [
@@ -54,7 +56,7 @@ module.exports = {
   // forceCoverageMatch: [],
 
   // A path to a module which exports an async function that is triggered once before all test suites
-  globalSetup: '<rootDir>/utils/waitApp.ts',
+  // globalSetup: '<rootDir>/utils/waitApp.ts',
 
   // A path to a module which exports an async function that is triggered once after all test suites
   // globalTeardown: undefined,
@@ -114,7 +116,7 @@ module.exports = {
   // restoreMocks: false,
 
   // The root directory that Jest should scan for tests and modules within
-  rootDir: "./src",
+  rootDir: './src',
 
   // A list of paths to directories that Jest should use to search for files in
   // roots: [
@@ -137,7 +139,7 @@ module.exports = {
   // snapshotSerializers: [],
 
   // The test environment that will be used for testing
-  testEnvironment: "node",
+  testEnvironment: 'node',
 
   // Options that will be passed to the testEnvironment
   // testEnvironmentOptions: {},

--- a/src/components/post/post.spec.ts
+++ b/src/components/post/post.spec.ts
@@ -5,6 +5,7 @@ import httpStatus from 'http-status-codes';
 import Requester from '../../appRequester';
 import db from '../../appDatabase';
 import logger from '../../appLogger';
+import waitApp from '../../utils/waitApp';
 
 const app = new Requester();
 
@@ -26,6 +27,16 @@ const basePost = {
   title: 'Lorem ipsum',
   content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
 };
+
+// Wait for all external services (db, redis...)
+beforeAll(async () => {
+  await waitApp();
+});
+
+// Gracefully terminate prisma query engine
+afterAll(async () => {
+  await db.$disconnect();
+});
 
 // Reset session before each test, create two user and log in
 beforeEach(async () => {
@@ -182,7 +193,7 @@ test('Get post - unknown post', async () => {
   await app.getPost('me', 'unknown', httpStatus.NOT_FOUND);
 });
 
-/*  Update post  */
+/*  Update post */
 
 test('Update post - auth', async () => {
   await app.createPost('me', basePost);
@@ -230,6 +241,7 @@ test('Update post - unknown post', async () => {
 });
 
 /*  Delete posts  */
+
 test('Delete post - auth', async () => {
   const { id } = await app.createPost('me', basePost);
   await app.signout();

--- a/src/components/user/user.spec.ts
+++ b/src/components/user/user.spec.ts
@@ -6,6 +6,7 @@ import { Role } from '@prisma/client';
 import Requester from '../../appRequester';
 import db from '../../appDatabase';
 import logger from '../../appLogger';
+import waitApp from '../../utils/waitApp';
 import { config } from '../../appConfig';
 import seedAdminUser from '../../utils/seedAdminUser';
 
@@ -21,6 +22,16 @@ const adminUser = {
   email: config.defaultAdminEmail,
   password: config.defaultAdminPassword,
 };
+
+// Wait for all external services (db, redis...)
+beforeAll(async () => {
+  await waitApp();
+});
+
+// Gracefully terminate prisma query engine
+afterAll(async () => {
+  await db.$disconnect();
+});
 
 // Reset session before each test
 beforeEach(() => {
@@ -202,7 +213,7 @@ test('Signout - Not logged in', async () => {
   await app.signout(httpStatus.UNAUTHORIZED);
 });
 
-/*  List users */
+/*  List users  */
 
 test('List users - auth', async () => {
   await app.listUsers(httpStatus.UNAUTHORIZED);
@@ -364,6 +375,8 @@ test('Update user - admin', async () => {
 
   await app.updateUser('unknownUserId', {}, httpStatus.NOT_FOUND);
 });
+
+/*  Delete user */
 
 test('Delete user - auth', async () => {
   const { id } = await app.signup(baseUser);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,23 @@
 import app from './app';
-import { config } from './appConfig';
+import db from './appDatabase';
 import logger from './appLogger';
+import { config } from './appConfig';
 import waitApp from './utils/waitApp';
 import seedAdminUser from './utils/seedAdminUser';
 
 const { port } = config;
 
-(async function main() {
+async function main() {
   await waitApp();
   await seedAdminUser();
   app.listen(port, () => logger.info(`Server listening on port ${port} on mode ${config.mode}...`));
-}());
+}
+
+main()
+  .catch((error) => {
+    logger.error(error);
+    throw error;
+  })
+  .finally(async () => {
+    await db.$disconnect();
+  });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,7 +65,8 @@
   },
   "include": [
     "src/**/*.ts",
-    ".eslintrc.js"
+    ".eslintrc.js",
+    "jest.config.js"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
**Context**

Jest launches one subprocess per test suites
To this is added one other subprocess, the *globalSetup*

Each of those subprocesses does not correctly clear **Prisma query engine**, so they stay as orphan processes

**Solution**

This PR move the setup logic into the *beforeAll* hook of Jest, located directly **inside** test suites, so the *globalSetup* is not anymore needed

Since the database is instanciated from **inside** test suites, it enables calling **prisma.$disconnect** in the *afterAll* hook of Jest